### PR TITLE
Implement SIP6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 RUN apt-get update
-RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim
+RUN apt-get upgrade -y
+RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs
 ADD https://raw.githubusercontent.com/mongodb/mongo/v3.2/debian/init.d /etc/init.d/mongod
 RUN chmod +x /etc/init.d/mongod
 WORKDIR /root

--- a/config/storj-bridge/config.json
+++ b/config/storj-bridge/config.json
@@ -39,5 +39,25 @@
   "redis": {
     "host": "localhost",
     "port": 6379
+  },
+  "application": {
+    "activateSIP6": true,
+    "powOpts": {
+      "retargetPeriod": 10000,
+      "retargetCount": 10
+    },
+    "shardsPerMinute": 1000,
+    "freeTier": {
+      "up": {
+        "hourlyBytes": 3000000000,
+        "dailyBytes": 10000000000,
+        "monthlyBytes": 60000000000
+      },
+      "down": {
+        "hourlyBytes": 9000000000,
+        "dailyBytes": 30000000000,
+        "monthlyBytes": 180000000000
+      }
+    }
   }
 }

--- a/config/storj-bridge/config.json
+++ b/config/storj-bridge/config.json
@@ -46,6 +46,9 @@
       "retargetPeriod": 10000,
       "retargetCount": 10
     },
+    "publishBenchThreshold": 4000,
+    "publishTotal": 36,
+    "publishBenchTotal": 9,
     "shardsPerMinute": 1000,
     "freeTier": {
       "up": {

--- a/config/storj-share/farmer-1/config.json
+++ b/config/storj-share/farmer-1/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-10/config.json
+++ b/config/storj-share/farmer-10/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-11/config.json
+++ b/config/storj-share/farmer-11/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-12/config.json
+++ b/config/storj-share/farmer-12/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-13/config.json
+++ b/config/storj-share/farmer-13/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-14/config.json
+++ b/config/storj-share/farmer-14/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-15/config.json
+++ b/config/storj-share/farmer-15/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-16/config.json
+++ b/config/storj-share/farmer-16/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-2/config.json
+++ b/config/storj-share/farmer-2/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-3/config.json
+++ b/config/storj-share/farmer-3/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-4/config.json
+++ b/config/storj-share/farmer-4/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-5/config.json
+++ b/config/storj-share/farmer-5/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-6/config.json
+++ b/config/storj-share/farmer-6/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-7/config.json
+++ b/config/storj-share/farmer-7/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-8/config.json
+++ b/config/storj-share/farmer-8/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/config/storj-share/farmer-9/config.json
+++ b/config/storj-share/farmer-9/config.json
@@ -6,10 +6,10 @@
     "0f03020202"
   ],
   "maxOfferConcurrency": 16,
-  "bridgeUri": "http://localhost:8080",
-  "renterWhitelist": [
-    "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
-  ],
+  "bridges": [{
+    "url": "http://localhost:8080",
+    "extendedKey": "xpub6ABDixD5jpQUDWNzHFh2WgAuANKDeTHmeXqLYaXsUuzpvfN8ZvbfBMXXbYkoq1kCvvpbiNE9zAzeC9VQh8dMNDb8mjc8cUh8F4jaUmFkyjr"
+  }],
   "seedList": [
     "storj://localhost:4000/337472da3068fa05d415262baf4df5bada8aefdc",
     "storj://localhost:4001/b2e1173bf733aeaacf79bf73a5a65bc5a912d923",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
+    "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
     "storj-mongodb-adapter": "storj/mongodb-adapter",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#b414b1fde7058c09fd231fda9241c20c74698ffe",
+    "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
-    "storj-service-storage-models": "braydonf/storj-service-storage-models#d0115e0f8626ef09bdf6bbbdf3699fdc2088b51d",
+    "storj-service-storage-models": "braydonf/storj-service-storage-models#46105c513501591196ccbbf2a3dfad9648fa0e79",
     "storjshare-daemon": "braydonf/storjshare-daemon#7cb292258c4b60369476137164ce7e4e54cc5ff3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
     "storj-complex": "braydonf/storj-complex#2913b7daa5037213f0617d873f805b3cbe7efd85",
-    "storj-lib": "braydonf/storj-lib#552fd3ca3e25f82a80bf5fb8a7f7f32ffcb79b5d",
+    "storj-lib": "braydonf/storj-lib#605308b7698b5f4c0202e279f15c8ffa21dd60aa",
     "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
-    "storj-service-storage-models": "braydonf/storj-service-storage-models#302b6fd47fe1c59c482009bb61cb08e1d7a802ab",
+    "storj-service-storage-models": "braydonf/storj-service-storage-models#d0115e0f8626ef09bdf6bbbdf3699fdc2088b51d",
     "storjshare-daemon": "braydonf/storjshare-daemon#b78035339ec03f7f86df5fbd64fb6dba20b9bc4e"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#c2e1149227f57654d852b3ba1e0cb737012f2d79",
-    "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#21b5a0b804cf9d4b91d589c0764e0aa08a196231",
-    "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
+    "storj-bridge": "storj/bridge",
+    "storj-complex": "storj/complex",
+    "storj-lib": "storj/core",
+    "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
-    "storj-service-storage-models": "braydonf/storj-service-storage-models#46105c513501591196ccbbf2a3dfad9648fa0e79",
+    "storj-service-storage-models": "storj/service-storage-models",
     "storjshare-daemon": "braydonf/storjshare-daemon#7cb292258c4b60369476137164ce7e4e54cc5ff3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
-    "storj-mongodb-adapter": "storj/mongodb-adapter",
+    "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#59f92377ba1703a12fd0f18a597ebbd4eb186ad4",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
+    "storj-bridge": "braydonf/storj-bridge#e8964edfd36bb7c6f13852530ca029db9326beea",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
+    "storj-lib": "braydonf/storj-lib#579dbf9e9331025bdd26e9985cbff876b8b6a66e",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
     "storj-complex": "braydonf/storj-complex#2913b7daa5037213f0617d873f805b3cbe7efd85",
-    "storj-lib": "braydonf/storj-lib#605308b7698b5f4c0202e279f15c8ffa21dd60aa",
+    "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
     "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
-    "storj-complex": "braydonf/storj-complex#50e5911cf01a758ae0099afe0c1fa5983fe50785",
+    "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
     "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "storj/bridge",
-    "storj-complex": "storj/complex",
-    "storj-lib": "storj/core",
+    "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
+    "storj-complex": "braydonf/storj-complex#2913b7daa5037213f0617d873f805b3cbe7efd85",
+    "storj-lib": "braydonf/storj-lib#552fd3ca3e25f82a80bf5fb8a7f7f32ffcb79b5d",
     "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
-    "storj-service-storage-models": "storj/service-storage-models",
-    "storjshare-daemon": "storj/storjshare-daemon"
+    "storj-service-storage-models": "braydonf/storj-service-storage-models#302b6fd47fe1c59c482009bb61cb08e1d7a802ab",
+    "storjshare-daemon": "braydonf/storjshare-daemon#b78035339ec03f7f86df5fbd64fb6dba20b9bc4e"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
     "storj-service-storage-models": "storj/service-storage-models",
-    "storjshare-daemon": "braydonf/storjshare-daemon#7cb292258c4b60369476137164ce7e4e54cc5ff3"
+    "storjshare-daemon": "storj/storjshare-daemon"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#3aa7e370c484d44cdd656625d8fe47df232e00d6",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#579dbf9e9331025bdd26e9985cbff876b8b6a66e",
+    "storj-lib": "braydonf/storj-lib#d10c1397aaef1f77e1656901d1d2b4d4f1259e1d",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#b414b1fde7058c09fd231fda9241c20c74698ffe",
-    "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#59f92377ba1703a12fd0f18a597ebbd4eb186ad4",
+    "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#3aa7e370c484d44cdd656625d8fe47df232e00d6",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#d10c1397aaef1f77e1656901d1d2b4d4f1259e1d",
+    "storj-lib": "braydonf/storj-lib#21b5a0b804cf9d4b91d589c0764e0aa08a196231",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#de27761284d59526cd11831a83df4de682c754ce",
+    "storj-bridge": "braydonf/storj-bridge#c2e1149227f57654d852b3ba1e0cb737012f2d79",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#21b5a0b804cf9d4b91d589c0764e0aa08a196231",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#3aa7e370c484d44cdd656625d8fe47df232e00d6",
+    "storj-bridge": "braydonf/storj-bridge#de27761284d59526cd11831a83df4de682c754ce",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#21b5a0b804cf9d4b91d589c0764e0aa08a196231",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   },
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#636d9a55a794872a29ce865c525c2c7b5ed0fa30",
-    "storj-complex": "braydonf/storj-complex#2913b7daa5037213f0617d873f805b3cbe7efd85",
+    "storj-complex": "braydonf/storj-complex#50e5911cf01a758ae0099afe0c1fa5983fe50785",
     "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
     "storj-mongodb-adapter": "storj/mongodb-adapter",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",
     "storj-service-middleware": "storj/service-middleware",
     "storj-service-storage-models": "braydonf/storj-service-storage-models#d0115e0f8626ef09bdf6bbbdf3699fdc2088b51d",
-    "storjshare-daemon": "braydonf/storjshare-daemon#b78035339ec03f7f86df5fbd64fb6dba20b9bc4e"
+    "storjshare-daemon": "braydonf/storjshare-daemon#7cb292258c4b60369476137164ce7e4e54cc5ff3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "storjshare-start": "./bin/storjshare-start"
   },
   "dependencies": {
-    "storj-bridge": "braydonf/storj-bridge#e8964edfd36bb7c6f13852530ca029db9326beea",
+    "storj-bridge": "braydonf/storj-bridge#3aa7e370c484d44cdd656625d8fe47df232e00d6",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
     "storj-lib": "braydonf/storj-lib#579dbf9e9331025bdd26e9985cbff876b8b6a66e",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#b414b1fde7058c09fd231fda9241c20c74698ffe",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "storj-bridge": "braydonf/storj-bridge#55fb90bd56ba684ecc4dbed67bcdd32f13dbd088",
     "storj-complex": "braydonf/storj-complex#1aba99ceef0fc40b77d4627255742ee766ce447b",
-    "storj-lib": "braydonf/storj-lib#48fa6d142acde270b8c8e5374c7987529b89a93c",
+    "storj-lib": "braydonf/storj-lib#b414b1fde7058c09fd231fda9241c20c74698ffe",
     "storj-mongodb-adapter": "braydonf/storj-mongodb-adapter#59f92377ba1703a12fd0f18a597ebbd4eb186ad4",
     "storj-service-error-types": "storj/service-error-types",
     "storj-service-mailer": "storj/service-mailer",


### PR DESCRIPTION
Implements https://github.com/Storj/sips/blob/master/sip-0006.md

Combines these branches for development:
- https://github.com/Storj/core/pull/704
- https://github.com/Storj/complex/pull/71
- https://github.com/Storj/service-storage-models/pull/117
- https://github.com/Storj/bridge/pull/464
- https://github.com/Storj/storjshare-daemon/pull/230

**Todo**:
- [x] Add `publishContract` to complex client
- [x] Update `lastContractSent` on the `contact` when publish message sent (or equivalent)
- [x] Update storage models to have updated fields for contact and necessary indexes
- [x] Connect `_selectFarmers` and `_publishContract` to `addShardToFrame`
- [x] Make sure that contract is sent to nodes/farmers with capacity available
- [x] Determine value for `PUBLISH_BENCH_THRESHOLD` (now configurable)

**Testing**:
- Change `config/storj-bridge/config.json` value `activateSIP6` to `true` and `false` and test uploading as described at https://github.com/Storj/integration#testing-file-transfers
- To test SIP6 further:
  -  Comment lines for `farmer.join` in `./scripts/farmer.js` in `storjshare-daemon`
  -  Run `./script/stop_everything.sh`
  -  Clear the contacts collection from mongodb
  -  And then `./scripts/start_everything` and check that farmers join the bridges by looking at mongo
  -  Test that uploads are working as expected
