### PR TITLE
add libstorj

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 RUN apt-get update -yqq
 RUN apt-get upgrade -yqq
-RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs python-pip expect libtool autotools-dev automake libuv1-dev libmicrohttpd-dev bsdmainutils libcurl4-gnutls-dev libjson-c-dev nettle-dev curl
+RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs python-pip swig expect libtool autotools-dev automake libuv1-dev libmicrohttpd-dev bsdmainutils libcurl4-gnutls-dev libjson-c-dev nettle-dev curl
 ADD https://raw.githubusercontent.com/mongodb/mongo/v3.2/debian/init.d /etc/init.d/mongod
 RUN chmod +x /etc/init.d/mongod
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs
+RUN apt-get update -yqq
+RUN apt-get upgrade -yqq
+RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs expect libtool autotools-dev automake libuv1-dev libmicrohttpd-dev bsdmainutils libcurl4-gnutls-dev libjson-c-dev nettle-dev curl
 ADD https://raw.githubusercontent.com/mongodb/mongo/v3.2/debian/init.d /etc/init.d/mongod
 RUN chmod +x /etc/init.d/mongod
 WORKDIR /root
@@ -21,6 +21,12 @@ COPY bin /root/bin
 RUN source /root/.nvm/nvm.sh; \
     cd /root; \
     npm install;
+RUN chmod 655 /root/scripts/install_libstorj.sh
+# default LIBSTORJ_VERSION will storj/master
+# pass commit-ish to install that version
+ARG LIBSTORJ_VERSION=''
+ENV LIBSTORJ_VERSION=$LIBSTORJ_VERSION
+RUN /root/scripts/install_libstorj.sh $LIBSTORJ_VERSION
 EXPOSE 8080
 EXPOSE 9001
 EXPOSE 9002

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 RUN apt-get update -yqq
 RUN apt-get upgrade -yqq
-RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs expect libtool autotools-dev automake libuv1-dev libmicrohttpd-dev bsdmainutils libcurl4-gnutls-dev libjson-c-dev nettle-dev curl
+RUN apt-get install -y mongodb-org rabbitmq-server redis-server build-essential wget git python libkrb5-dev vim emacs python-pip expect libtool autotools-dev automake libuv1-dev libmicrohttpd-dev bsdmainutils libcurl4-gnutls-dev libjson-c-dev nettle-dev curl
 ADD https://raw.githubusercontent.com/mongodb/mongo/v3.2/debian/init.d /etc/init.d/mongod
 RUN chmod +x /etc/init.d/mongod
 WORKDIR /root

--- a/scripts/install_libstorj.sh
+++ b/scripts/install_libstorj.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+libstorj_dir="$root_dir/libstorj"
+
+if [ $# -gt 0 ]; then
+  commit_ish=$1
+fi
+
+git clone https://github.com/storj/libstorj $libstorj_dir
+if [ ! -z $commit_ish ]; then
+  git checkout $commit_ish
+fi
+cd $libstorj_dir && \
+./autogen.sh && \
+./configure && \
+make && \
+if [ $(whoami) == "root" ]; then
+    make install
+    ldconfig
+else
+    sudo make install
+    sudo ldconfig
+fi
+


### PR DESCRIPTION
This installs libstorj cli (and a few more dependencies/tools) on the integraiton container.

The version of libstorj can be specified by passing `--build-arg <commit-ish from libstorj>` when doing `docker build`, but it defaults to the head of the master branch of this repo.